### PR TITLE
Expose CDVCommandStatus enum to Swift

### DIFF
--- a/CordovaLib/Classes/Public/CDVPluginResult.h
+++ b/CordovaLib/Classes/Public/CDVPluginResult.h
@@ -20,7 +20,7 @@
 #import <Foundation/Foundation.h>
 #import "CDVAvailability.h"
 
-typedef enum {
+typedef NS_ENUM(NSUInteger, CDVCommandStatus)  {
     CDVCommandStatus_NO_RESULT = 0,
     CDVCommandStatus_OK,
     CDVCommandStatus_CLASS_NOT_FOUND_EXCEPTION,
@@ -31,7 +31,7 @@ typedef enum {
     CDVCommandStatus_INVALID_ACTION,
     CDVCommandStatus_JSON_EXCEPTION,
     CDVCommandStatus_ERROR
-} CDVCommandStatus;
+};
 
 @interface CDVPluginResult : NSObject {}
 


### PR DESCRIPTION
This allows Swift plugins to write code like 

``` swift
CDVPluginResult(status: .ERROR)
```

rather than 

``` swift
CDVPluginResult(status: CDVCommandStatus_ERROR)
```

Its use in Objective C is unchanged.
