### PR TITLE
fix(statusbar): Support setting alpha from the JS API

### DIFF
--- a/CordovaLib/Classes/Private/Plugins/CDVStatusBarInternal/CDVStatusBarInternal.m
+++ b/CordovaLib/Classes/Private/Plugins/CDVStatusBarInternal/CDVStatusBarInternal.m
@@ -37,8 +37,9 @@
     NSInteger valueR = [[command argumentAtIndex:0 withDefault:@0] integerValue];
     NSInteger valueG = [[command argumentAtIndex:1 withDefault:@0] integerValue];
     NSInteger valueB = [[command argumentAtIndex:2 withDefault:@0] integerValue];
+    NSInteger valueA = [[command argumentAtIndex:3 withDefault:@255] integerValue];
 
-    UIColor *bgColor = [UIColor colorWithRed:valueR/255.f green:valueG/255.f blue:valueB/255.f alpha:1.f];
+    UIColor *bgColor = [UIColor colorWithRed:valueR/255.f green:valueG/255.f blue:valueB/255.f alpha:valueA/255.f];
     [self.viewController setStatusBarBackgroundColor:bgColor];
 }
 


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes GH-1659


### Description
<!-- Describe your changes in detail -->
Parse and use an alpha value if it is provided (otherwise fallback to being opaque like the current behaviour).


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
